### PR TITLE
Adding a direct message link in tweets

### DIFF
--- a/index.js
+++ b/index.js
@@ -77,11 +77,11 @@ function TwitterBot() {
 				console.log(message);
 
 				if(message.length > 140){
-					tweetIt('@' + from + ' Sorry due to tweet word limit, I have sent you a personal message. Check inbox'+date);
+					tweetIt('@' + from + ' Sorry due to tweet word limit, I have sent you a personal message. Check inbox'+date+"\nhttps://twitter.com/messages/compose?recipient_id=871446601000202244");
 					sendMessage(from, message);
 				}
 				else{
-					tweetIt('@' + from + ' ' + message + date);
+					tweetIt('@' + from + ' ' + message + date +"\nhttps://twitter.com/messages/compose?recipient_id=871446601000202244");
 				}
 			});
 		}


### PR DESCRIPTION
Fixes issue #31 i.e. to show a dm link as an option to users in a tweet.

Screenshots for the change: 
<img width="441" alt="dmlinkintweet" src="https://user-images.githubusercontent.com/20307535/29038780-889636c0-7bc6-11e7-9553-2cf9126fb94b.PNG">

When we click the dm link, we can type a message with that tweet as a reference and get a reply from SUSI. 
<img width="416" alt="dmclicked" src="https://user-images.githubusercontent.com/20307535/29038790-9247bd1a-7bc6-11e7-945d-ff121cd530a5.PNG">